### PR TITLE
show which ctf is active or planned

### DIFF
--- a/plugins/ctf.rb
+++ b/plugins/ctf.rb
@@ -89,6 +89,8 @@ class CTFPlugin
       if @credentials.has_key?(ctf.title) && @creds_authorized.include?(message.user.nick)
         creds = @credentials[ctf.title].reject(&:nil?).map { |x| "'#{x}'" }.join(':')
         msg << " - #{creds}"
+      elsif @credentials.has_key?(ctf.title)
+        msg << " - active/planned"
       end
       msg << "\n"
     end


### PR DESCRIPTION
if there is a ctf which there are creds set for, and one who triggers !ctfs isn't authorized to see the creds, instead of showing that ctf in the same format as other, it now appends ' - active/planned' so the one who sees the list would be notifed which ctf the team is or planned to participate.