### PR TITLE
feat(ctfs plugin): add 'participating' trailing message on :ctfs for unauthorized users

### DIFF
--- a/plugins/ctf.rb
+++ b/plugins/ctf.rb
@@ -89,6 +89,8 @@ class CTFPlugin
       if @credentials.has_key?(ctf.title) && @creds_authorized.include?(message.user.nick)
         creds = @credentials[ctf.title].reject(&:nil?).map { |x| "'#{x}'" }.join(':')
         msg << " - #{creds}"
+      elsif @credentials.has_key?(ctf.title)
+        msg << " - participating"
       end
       msg << "\n"
     end


### PR DESCRIPTION
Hi, the code is altered to show ' - participating' trail instead of ' - <creds>' for unauthorized users using :ctfs command, so they'll be announced which ctf the team has registered for, thus planning to participate.